### PR TITLE
Corrected type definitions for Handler's response generics and the typing of the Handler's _get, _put, _post, and _delete.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@breautek/storm",
       "version": "4.1.0",
-      "license": "GPL-3.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@arashi/token": "1.0.1",
         "@breautek/merge-change": "1.0.0",

--- a/spec/api.spec.ts
+++ b/spec/api.spec.ts
@@ -75,4 +75,8 @@ describe('Public API', () => {
     it('DropTemporaryTableQuery', () => {
         expect(api.DropTemporaryTableQuery).toBeTruthy();
     });
+
+    it('NotImplementedError', () => {
+        expect(api.NotImplementedError).toBeTruthy();
+    });
 });

--- a/spec/errors/NotImplementedError.spec.ts
+++ b/spec/errors/NotImplementedError.spec.ts
@@ -1,0 +1,78 @@
+
+import {NotImplementedError} from '../../src/NotImplementedError';
+import { HTTPMethod } from '../../src/HTTPMethod';
+import {IErrorResponse} from '../../src/StormError';
+import {
+    MockApplication
+} from '../support/TestApplication';
+import {ErrorCode} from '../../src/ErrorCode';
+import {StatusCode} from '../../src/StatusCode';
+
+describe('NotImplementedError', () => {
+    let error: NotImplementedError = null;
+    let app: MockApplication = null;
+
+    let setup = (done: any) => {
+        process.argv = [];
+        app = new MockApplication();
+        app.on('ready', () => {
+            error = new NotImplementedError(HTTPMethod.GET);
+            done();
+        });
+    };
+
+    let deconstruct = (done: any) => {
+        app.close().then(() => {
+            app = null;
+            error = null;
+            done();
+        });
+    };
+
+    beforeAll(setup);
+    afterAll(deconstruct);
+
+    it('GET has error message', () => {
+        expect(new NotImplementedError(HTTPMethod.GET).getMessage()).toBe('Handler does not implement "GET".');
+    });
+
+    it('PUT has error message', () => {
+        expect(new NotImplementedError(HTTPMethod.PUT).getMessage()).toBe('Handler does not implement "PUT".');
+    });
+    it('POST has error message', () => {
+        expect(new NotImplementedError(HTTPMethod.POST).getMessage()).toBe('Handler does not implement "POST".');
+    });
+    it('DELETE has error message', () => {
+        expect(new NotImplementedError(HTTPMethod.DELETE).getMessage()).toBe('Handler does not implement "DELETE".');
+    });
+
+    it('has code', () => {
+        expect(error.getCode()).toBe(ErrorCode.INTERNAL);
+    });
+
+    it('has HTTP code', () => {
+        expect(error.getHTTPCode()).toBe(StatusCode.INTERNAL_NOT_IMPLEMENTED);
+    });
+
+    describe('getErrorResponse()', () => {
+        it('name', () => {
+            let r: IErrorResponse = error.getErrorResponse();
+            expect(r.name).toBe('NotImplementedError');
+        });
+
+        it('message', () => {
+            let r: IErrorResponse = error.getErrorResponse();
+            expect(r.message).toBe(error.getMessage());
+        });
+
+        it('code', () => {
+            let r: IErrorResponse = error.getErrorResponse();
+            expect(r.code).toBe(error.getCode());
+        });
+
+        it('details', () => {
+            let r: IErrorResponse = error.getErrorResponse();
+            expect(r.details).toEqual(error.getPublicDetails());
+        });
+    });
+});

--- a/spec/support/TestApplication.ts
+++ b/spec/support/TestApplication.ts
@@ -28,15 +28,15 @@ class TestHandler extends Handler {
 
     protected async _get(request: Request): Promise<void> {}
 
-    protected async _post(request: Request): Promise<void> {
+    protected async _post(request: Request): Promise<any> {
         return request.getBody();
     }
 
-    protected async _put(request: Request): Promise<void> {
+    protected async _put(request: Request): Promise<any> {
         return request.getBody();
     }
 
-    protected async _delete(request: Request): Promise<void> {
+    protected async _delete(request: Request): Promise<any> {
         return request.getBody();
     }
 }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -14,7 +14,6 @@
    limitations under the License.
 */
 
-import {StatusCode} from './StatusCode';
 import {Application} from './Application';
 import {getInstance} from './instance';
 import {Request} from './Request';
@@ -27,6 +26,8 @@ import { IRequestResponse } from './IRequestResponse';
 import { Logger } from '@arashi/logger';
 import { ResponseData } from './ResponseData';
 import { ReadStream } from 'fs';
+import { NotImplementedError } from './NotImplementedError';
+import { HTTPMethod } from './HTTPMethod';
 // import { Stream } from 'stream';
 
 const TAG: string = 'Handler';
@@ -62,7 +63,7 @@ export class Handler<
         TPutRequest     = any,
         TPutResponse    = IHandlerResponse,
         TDeleteRequest  = any,
-        TDeleteResponse = IHandlerResponse,
+        TDeleteResponse = ResponseData,
     >  {
         
     private $app: TApplication;
@@ -199,19 +200,19 @@ export class Handler<
         }
     }
 
-    protected async _get(request: Request<TGetRequest>): Promise<TGetResponse | IHandlerResponse> {
-        return new ResponseData(StatusCode.INTERNAL_NOT_IMPLEMENTED);
+    protected async _get(request: Request<TGetRequest>): Promise<TGetResponse> {
+        throw new NotImplementedError(HTTPMethod.GET);
     }
 
-    protected async _post(request: Request<TPostRequest>): Promise<TPostResponse| IHandlerResponse> {
-        return new ResponseData(StatusCode.INTERNAL_NOT_IMPLEMENTED);
+    protected async _post(request: Request<TPostRequest>): Promise<TPostResponse> {
+        throw new NotImplementedError(HTTPMethod.POST);
     }
 
-    protected async _put(request: Request<TPutRequest>): Promise<TPutResponse | IHandlerResponse> {
-        return new ResponseData(StatusCode.INTERNAL_NOT_IMPLEMENTED);
+    protected async _put(request: Request<TPutRequest>): Promise<TPutResponse> {
+        throw new NotImplementedError(HTTPMethod.PUT);
     }
 
-    protected async _delete(request: Request<TDeleteRequest>): Promise<TDeleteResponse | IHandlerResponse> {
-        return new ResponseData(StatusCode.INTERNAL_NOT_IMPLEMENTED);
+    protected async _delete(request: Request<TDeleteRequest>): Promise<TDeleteResponse> {
+        throw new NotImplementedError(HTTPMethod.DELETE);
     }
 }

--- a/src/NotImplementedError.ts
+++ b/src/NotImplementedError.ts
@@ -1,0 +1,45 @@
+/*
+   Copyright 2017-2021 Norman Breau
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import {StormError} from './StormError';
+import {ErrorCode} from './ErrorCode';
+import {StatusCode} from './StatusCode';
+import {HTTPMethod} from './HTTPMethod';
+
+interface INotImplementedErrorOptions {
+    method: string;
+}
+
+export class NotImplementedError extends StormError<INotImplementedErrorOptions> {
+    public constructor(method: HTTPMethod) {
+        super({
+            method
+        });
+    }
+
+    public getMessage(): string {
+        let details: INotImplementedErrorOptions = this.getPrivateDetails();
+        return `Handler does not implement "${details.method}".`;
+    }
+
+    public getCode(): ErrorCode {
+        return ErrorCode.INTERNAL;
+    }
+
+    public getHTTPCode(): StatusCode {
+        return StatusCode.INTERNAL_NOT_IMPLEMENTED;
+    }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -55,6 +55,7 @@ export {DiskSpaceError} from './DiskSpaceError';
 export {DuplicateEntryError} from './DuplicateEntryError';
 export {MissingConfigError} from './MissingConfigError';
 export {DatabaseQueryError} from './DatabaseQueryError';
+export {NotImplementedError} from './NotImplementedError';
 
 // HTTP
 export {StatusCode} from './StatusCode';


### PR DESCRIPTION
Added NotImplementedError.
Updated Handler _get, _post, _put, and _delete to throw NotImplementedError instead of returning ResponseData. This fixes the typing errors that returning ResponseData produced.
Updated TestHandler to correctly define the new typings.